### PR TITLE
feat(command): agregar comando para generar embeddings de provincias

### DIFF
--- a/src/Command/GenerateEmbeddingsCommand.php
+++ b/src/Command/GenerateEmbeddingsCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Command;
+
+use App\RAG\Agent\QuizProvinciasAgent;
+use Doctrine\ORM\EntityManagerInterface;
+use NeuronAI\RAG\DataLoader\StringDataLoader;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'app:generate-embeddings')]
+class GenerateEmbeddingsCommand
+{
+    public function __construct(private EntityManagerInterface $entityManager) {}
+
+    public function __invoke(SymfonyStyle $io)
+    {
+        try {
+            $io->title('Generating embeddings...');
+
+            $provincias = json_decode(
+                file_get_contents(__DIR__ . '/../Database/provincias.json'), 
+                true
+            );
+
+            foreach ($io->progressIterate($provincias['provincias']) as $provincia) {
+                $content = [
+                    'Nombre: '.$provincia['nombre'],
+                    'Capital: '.$provincia['capital'],
+                    'Poblacion: '.$provincia['poblacion'],
+                    'Superficie: '.$provincia['superficie'],
+                    'Gentilicio: '.$provincia['gentilicio'],
+                    'Fecha Autonomia: '.$provincia['fecha_autonomia'],
+                    'Abreviatura: '.$provincia['abreviatura'],
+                    'Ciudad mas poblada: '.
+                        'Nombre: '.$provincia['ciudad_mas_poblada']['nombre'].
+                        ', Habitantes: '.$provincia['ciudad_mas_poblada']['habitantes']
+                ];
+                $content = implode("|", $content);
+
+                $documents = StringDataLoader::for($content)->getDocuments();
+
+                foreach ($documents as $document) {
+                    $document->addMetadata('nombre', $provincia['nombre']);
+                    $document->addMetadata('capital', $provincia['capital']);
+                    $document->addMetadata('poblacion', $provincia['poblacion']);
+                    $document->addMetadata('superficie', $provincia['superficie']);
+                    $document->addMetadata('gentilicio', $provincia['gentilicio']);
+                    $document->addMetadata('fecha_autonomia', $provincia['fecha_autonomia']);
+                    $document->addMetadata('abreviatura', $provincia['abreviatura']);
+                    $document->addMetadata('ciudad_mas_poblada', json_encode($provincia['ciudad_mas_poblada']));
+                }
+
+                QuizProvinciasAgent::make($this->entityManager)->addDocuments($documents);
+            }
+
+            $io->success('Embeddings generated successfully.');
+
+            return Command::SUCCESS;
+        } catch (\Throwable $th) {
+            $io->error($th->getMessage());
+            
+            return Command::FAILURE;
+        }
+    }
+}

--- a/src/RAG/Agent/QuizProvinciasAgent.php
+++ b/src/RAG/Agent/QuizProvinciasAgent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\RAG\Agent;
+
+use App\RAG\VectorStore\DocumentDoctrineVectorStore;
+use Doctrine\ORM\EntityManagerInterface;
+use NeuronAI\Providers\AIProviderInterface;
+use NeuronAI\Providers\Ollama\Ollama;
+use NeuronAI\RAG\Embeddings\EmbeddingsProviderInterface;
+use NeuronAI\RAG\Embeddings\OllamaEmbeddingsProvider;
+use NeuronAI\RAG\RAG;
+use NeuronAI\RAG\VectorStore\VectorStoreInterface;
+use NeuronAI\SystemPrompt;
+
+class QuizProvinciasAgent extends RAG
+{
+    protected function __construct(private EntityManagerInterface $entityManager) {}
+
+    protected function provider(): AIProviderInterface
+    {
+        return new Ollama(
+            url: 'http://localhost:11434/api',
+            model: 'llama3.1:8b'
+        );
+    }
+
+    protected function embeddings(): EmbeddingsProviderInterface
+    {
+        return new OllamaEmbeddingsProvider(
+            model: 'nomic-embed-text'
+        );
+    }
+
+    protected function vectorStore(): VectorStoreInterface
+    {
+        return new DocumentDoctrineVectorStore(
+            entityManager: $this->entityManager
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces a new command for generating embeddings from provincial data and adds a specialized agent class to handle RAG (Retrieval-Augmented Generation) operations for provincial quiz data. The main changes focus on enabling the ingestion and embedding of province information, and integrating it with a vector store using Doctrine ORM.

**New Embeddings Command and Agent Integration**

* Added `GenerateEmbeddingsCommand` to read province data from a JSON file, process it into documents with metadata, and store the embeddings using the `QuizProvinciasAgent`.
* Introduced `QuizProvinciasAgent`, a subclass of `RAG`, which configures the AI provider, embeddings provider, and vector store for handling provincial quiz data.

**RAG and Vector Store Configuration**

* `QuizProvinciasAgent` uses Ollama as the AI provider and embeddings provider, and persists document embeddings using a Doctrine-based vector store.

These changes provide the foundation for embedding province information and making it searchable via RAG workflows in the application.